### PR TITLE
variable declaration typo fix.

### DIFF
--- a/Model/Export.php
+++ b/Model/Export.php
@@ -171,7 +171,7 @@ class Export
     /**
      * @var UrlFinderInterface
      */
-    protected $urlFinder;
+    protected $_urlFinder;
 
     /**
      * @var


### PR DESCRIPTION
Correction of urlFinder typo declaration. Was $urlFinder, but used in the file as $_urlFinder. PHP 8.2 caught the issue.